### PR TITLE
refactor: re-organize ci workflow and reusable workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,6 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - test-*
 
-  workflow_call:
-
   workflow_dispatch:
 
 jobs:
@@ -35,10 +33,6 @@ jobs:
     needs: [pre-commit, build-test]
 
     runs-on: ubuntu-latest
-
-    # outputs:
-    #   RELEASE_BRANCH_HEAD_REF: ${{ steps.set-release-branch.outputs.GITHUB_HEAD_REF }}
-    #   RELEASE_BRANCH_SPEC_VER: ${{ steps.set-release-branch.outputs.GITHUB_SPEC_VER }}
 
     steps:
 
@@ -66,10 +60,10 @@ jobs:
     # --- release validation starts from here --- #
     - shell: bash
       run: |
-        # validate that release branch specified version matches SemVer specification
+        # validate that release branch specified version matches release specification
         # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-        if [[ "${{steps.set-release-branch.outputs.GITHUB_SPEC_VER}}" =~ "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$" ]]; then
-          echo "Error: Release Branch Specified Version does not match SemVer Specification (Major.Minior.Patch+)."
+        if [[ "${{steps.set-release-branch.outputs.GITHUB_SPEC_VER}}" =~ "^[0-9]+\.[0-9]+\.[0-9]+$" ]]; then
+          echo "Error: Release Branch Specified Version does not match Release Specification (Major.Minior.Patch)."
           exit 1
         fi
 

--- a/.github/workflows/reusable-build-test.yaml
+++ b/.github/workflows/reusable-build-test.yaml
@@ -7,12 +7,6 @@ on:  # yamllint disable-line rule:truthy
   workflow_call:
     outputs:
 
-      # RELEASE_BRANCH_HEAD_REF:
-      #   value: ${{ jobs.validate-release-version.outputs.RELEASE_BRANCH_HEAD_REF }}
-
-      # RELEASE_BRANCH_SPEC_VER:
-      #   value: ${{ jobs.validate-release-version.outputs.RELEASE_BRANCH_SPEC_VER }}
-
       ARTIFACT_ID:
         value: ${{ jobs.build.outputs.ARTIFACT_ID }}
 
@@ -28,9 +22,6 @@ permissions:
   contents: read
 
 jobs:
-
-  # pre-ci:
-  #   uses: ./.github/workflows/reusable-pre-commit.yaml
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
break up cicd because the trigger for CI and CD are different.  The former is triggred by test-based branch and PR to main while the latter is triggered by merged PR.