### PR TITLE
fix: update optional dependencies and add tool.pyproject-fmt section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "setuptools==80.3.1",
   "virtualenv==20.31.2",
 ]
-optional-dependencies.test = [ "commitizen", "coverage", "flake8", "isort", "pre-commit" ]
+optional-dependencies.test = [ "build", "commitizen", "coverage", "flake8", "isort", "pre-commit", "twine" ]
 
 urls.Changelog = "https://www.notavailable.com/changelog"
 urls.Documentation = "https://www.notavailable.com/doc"
@@ -47,6 +47,11 @@ where = [ "src" ]
 
 [tool.setuptools.dynamic]
 version = { attr = "src.pkg_15903.__init__" }
+
+[tool.pyproject-fmt]
+column_width = 125
+indent = 2
+keep_full_version = true
 
 [tool.coverage]
 source = [ "." ]


### PR DESCRIPTION
- Update optional dependencies to add build and twine so that they can be placed inside Makefile.
- add [tool.pyproject-fmt] section to add control on keep_full_version.  Without this setting, when Dependabot creates a PR with a version that has a trailing zero, pyproject-fmt hook will fail the pre-commit check. 