### PR TITLE
fix: pin pip command with hash

### DIFF
--- a/.github/workflows/cd-production.yaml
+++ b/.github/workflows/cd-production.yaml
@@ -34,9 +34,9 @@ jobs:
 
     - shell: bash
       run: |
-        # install build dependencies
+        # install dependencies and build
+        make test-install
         make build
-        python -m pip install -U twine
 
     - shell: bash
       run: |
@@ -74,7 +74,7 @@ jobs:
         INDEX_URL: "https://pypi.org/simple/"
       run: |
         # install package from PyPI and run app to show version
-        pip install ${{ env.PACKAGE_NAME }}
+        python -m pip install ${{ env.PACKAGE_NAME }}==${{ github.ref_name }}
         ${{ env.PACKAGE_NAME }} --version
 
   notify-slack:

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -82,9 +82,9 @@ jobs:
 
     - shell: bash
       run: |
-        # install build dependencies
+        # install dependencies and build
+        make test-install
         make build
-        python -m pip install -U twine
 
     - shell: bash
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "setuptools==80.7.1",
   "virtualenv==20.31.2",
 ]
-optional-dependencies.test = [ "build", "commitizen", "coverage", "flake8", "isort", "pre-commit", "twine" ]
+optional-dependencies.test = [ "build", "commitizen", "coverage", "flake8", "isort", "pre-commit", "pyscan-rs", "twine" ]
 
 urls.Changelog = "https://www.notavailable.com/changelog"
 urls.Documentation = "https://www.notavailable.com/doc"


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_OSSF Pinned-Dependencies list pipCommand not pinned with hash_


<!-- What's the goal of the Pull Request? -->
#### Why is this PR created?

_Fix OSSF Pinned-Dependencies_


<!-- What's been changed by this PR? -->
#### What is on the PR?

* pip install xxxx
* update pyproject to add dependencies that Makefile can use to make install 
