### PR TITLE
fix: on CD staging workflow, skipped-all-jobs shows as failure

### DIFF
--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -144,6 +144,8 @@ jobs:
         # get overall result from all of the previous jobs
         if "${{ needs.push-git-tag.result == 'success' && needs.publish-TestPyPI.result == 'success' && needs.validate-TestPyPI.result == 'success' }}"; then
           echo "WORKFLOW_RESULT=:white_check_mark:" >> "$GITHUB_OUTPUT"
+        elif "${{ needs.push-git-tag.result == 'skipped' && needs.publish-TestPyPI.result == 'skipped' && needs.validate-TestPyPI.result == 'skipped' }}"; then
+          echo "WORKFLOW_RESULT=:fast_forward:" >> "$GITHUB_OUTPUT"
         else
           echo "WORKFLOW_RESULT=:no_entry:" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_on CD staging workflow, skipped-all-jobs shows as failure_


<!-- What's the goal of the Pull Request? -->
#### Why is this PR created?

_add elif statement for all-skipped-jobs condition._


<!-- What's been changed by this PR? -->
#### What is on the PR?

* cd-staging
