### PR TITLE
refactor: switch pypi publishing from shell to GHA

### DIFF
--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -92,14 +92,25 @@ jobs:
         tree dist/
         python -m twine check  dist/*
 
-    - shell: bash
-      env:
-        TWINE_USERNAME: "__token__"
-        TWINE_PASSWORD: "${{ secrets.SECRET_PYPITEST }}"
-        TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
-      run: |
-        # Publish distributions to TestPyPI
-        python -m twine upload --verbose dist/*
+    - name: Publish package distributions to TestPyPI
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      with:
+        name: testpypi
+        packages-dir: dist/
+        password: ${{ secrets.SECRET_PYPITEST }}
+        print-hash: true
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true
+        verify-metadata: true
+
+    # - shell: bash
+    #   env:
+    #     TWINE_USERNAME: "__token__"
+    #     TWINE_PASSWORD: "${{ secrets.SECRET_PYPITEST }}"
+    #     TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
+    #   run: |
+    #     # Publish distributions to TestPyPI
+    #     python -m twine upload --verbose dist/*
 
   validate-TestPyPI:
 


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_OSSF score 0 for publishing without using GHA_


<!-- What's the goal of the Pull Request? -->
#### Why is this PR created?

_switch from shell twine upload to GHA_


<!-- What's been changed by this PR? -->
#### What is on the PR?

* cd-staging

