### PR TITLE
fix: add git account identity to coverage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -82,12 +82,11 @@ jobs:
         # use template.json to create/replace coverage.json
         sed -e 's/TPL_LABEL/Coverage/g;s/TPL_LCOLOR/2e2e2e/g;s/TPL_MESSAGE/${{ steps.get-coverage-results.outputs.COV_PER }}/g;s/TPL_COLOR/2ade2a/g' template.json > coverage.json
 
-    - name: check in the changes
-      run: |
-        # checkin the new/updated coverage.json
-        git add coverage.json
-        git commit -m 'create/update coverage.json'
-        git push -u origin coverage
+    - run: git config --global user.email "mona-lisa@tagdots.com"
+    - run: git config --global user.name "Mona Lisa"
+    - run: git add coverage.json
+    - run: git commit -m 'create/update coverage.json'
+    - run: git push -u origin coverage
 
   notify-slack:
     if: always()


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_git command fail due to account identity_


<!-- What's the goal of the Pull Request? -->
#### Why is this PR created?

_add git account identity to coverage._


<!-- What's been changed by this PR? -->
#### What is on the PR?

* coverage workflow
