### PR TITLE
cron-workflow-test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - test-*
 
+  schedule:
+    - cron: '*/6 * * * *'
+
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Create a schedule at CI to run every 6 mins.  This is to create lots of workflows so that I can test with my delete-workflow app.