### PR TITLE
test: replace patch target to use requests.get within the ClsRequests…

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -36,14 +36,14 @@ class TestCLI(unittest.TestCase):
         self.assertIn("HTTPError", str(result.exception))
         self.assertNotEqual(result.exit_code, 0)
 
-    @patch('requests.get')
+    @patch('pkg_15903.core.cls_requests.requests.get')
     def test_cli_main_connection_error(self, mock_get):
         mock_get.side_effect = requests.exceptions.ConnectionError()
         result = self.runner.invoke(main, ['--url', 'https://example.com'])
         self.assertIn("500: Error_Type - ConnectionError", str(result.exception))
         self.assertNotEqual(result.exit_code, 0)
 
-    @patch('requests.get')
+    @patch('pkg_15903.core.cls_requests.requests.get')
     def test_cli_main_requests_error(self, mock_get):
         mock_get.side_effect = requests.exceptions.RequestException()
         result = self.runner.invoke(main, ['--url', 'https://example.com'])


### PR DESCRIPTION
<!-- NOTE: this file is managed by Terraform -->
<!-- Describe the issue -->
#### Issue Summary
_Summary of the issue_
The mock is patching 'requests.get' globally, but based on the context file cls_requests.py, the actual implementation uses requests.get within the ClsRequests class. The patch target should be 'pkg_15903.core.cls_requests.requests.get' to ensure the mock is applied where the code actually calls requests.get. This may cause the test to not properly verify the error handling behavior.

<!-- What is the goal of the Pull Request? -->
#### Why was this PR created?
_This PR accomplishes the following...._
- replace patch target to use the context file - cls_requests.py

