### PR TITLE
build: fix duplicate header by breaking the a multi-step job into 2 jobs

### DIFF
--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -18,8 +18,9 @@ permissions:
     pull-requests: read
 
 jobs:
-  badge-coverage: # https://github.com/tagdots/setup-badge-action
+  pre-badge-coverage:
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
 
@@ -41,6 +42,7 @@ jobs:
 
     - id: coverage-run
       env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PYTHONUNBUFFERED: "1"
       run: make test
 
@@ -60,13 +62,20 @@ jobs:
         overwrite: true
         compression-level: 6
 
+  badge-coverage: # https://github.com/tagdots/setup-badge-action
+    runs-on: ubuntu-latest
+    needs: pre-badge-coverage
+    permissions:
+      contents: write
+
+    steps:
     - id: coverage-badge
       uses: tagdots/setup-badge-action@294661aa1f149b59dfe1cd187539eca7f8f0fabf # 1.0.18
       with:
         badge-name: coverage
-        badge-url: https://github.com/tagdots/setup-badge/actions/workflows/cron-tasks.yaml
+        badge-url: https://github.com/tagdots-dev/badge-test/actions/workflows/cron-tasks.yaml
         label: "Code Coverage"
-        message: "${{ steps.get-coverage-results.outputs.COV_PER }}"
+        message: "${{ needs.pre-badge-coverage.outputs.COV_PER }}"
 
   badge-demo: # https://github.com/tagdots/setup-badge-action
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- NOTE: Terraform-managed template -->
<!-- Describe the issue -->
#### Issue Summary
_action/checkout since v6 causes duplicate header error (http status code: 400). It is determined that both badge job runs action/checkout twice (with the second run from setup-badge-action)_


<!-- What is the goal of the Pull Request? -->
#### Why is this PR created?
_Break setup-badge-action out to another job so that we don't run action/checkout twice._
