### PR TITLE
build: Replace python security scan

### DIFF
--- a/.github/workflows/reusable-pre-commit.yaml
+++ b/.github/workflows/reusable-pre-commit.yaml
@@ -34,10 +34,9 @@ jobs:
         # install package
         make local-install
 
-    - shell: bash
-      run: |
-        # Pyscan vulnerabilities on python dependencies
-        [[ ! -f "requirements.txt" && ! -f "pyproject.toml" ]] || pyscan -d .
+    - name: Pysentry to scan for transitive vulnerabilities on required dependencies
+      shell: bash
+      run: pysentry-rs --fail-on high --exclude-extra --no-fail-on-unknown --forbid-quarantined
 
     - shell: bash
       run: |

--- a/.github/workflows/sidecar-pr-target.yaml
+++ b/.github/workflows/sidecar-pr-target.yaml
@@ -1,7 +1,5 @@
 ---
-# NOTE: this file is managed by terraform
 
-# trigger job run on event pull_request_target
 name: sidecar-pr-target
 
 on:  # yamllint disable-line rule:truthy
@@ -46,8 +44,8 @@ jobs:
         payload: |
           channel: "${{ secrets.SECRET_SLACK_CHANNEL_PR }}"
           text: ":fire: *Pull Request (re)opened or updated.*
-          ```
-          Repo  : ${{ github.repository }}\n
-          Branch: ${{ github.event.pull_request.head.ref }}\n
-          PR URL: ${{ github.event.pull_request.html_url }}
-          ```"
+            ```
+            Repo  : ${{ github.repository }}\n
+            Branch: ${{ github.event.pull_request.head.ref }}\n
+            PR URL: ${{ github.event.pull_request.html_url }}
+            ```"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ optional-dependencies.test = [
   "coverage",
   "flake8",
   "isort",
-  "pyscan-rs",
+  "pysentry-rs",
   "twine",
 ]
 urls.Changelog = "https://www.notavailable.com/changelog"


### PR DESCRIPTION
<!-- NOTE: Terraform-managed template -->
<!-- Describe the issue -->
#### Issue Summary
_pysentry is more user-friendly and well-maintained than pyscan-rs_

#### Why is this PR created?
This PR accomplishes the following....
- Replace Python security scan from pyscan to pysentry