### PR TITLE
build: Replace python security scan

### DIFF
--- a/.github/workflows/reusable-pre-commit.yaml
+++ b/.github/workflows/reusable-pre-commit.yaml
@@ -34,10 +34,9 @@ jobs:
         # install package
         make local-install
 
-    - shell: bash
-      run: |
-        # Pyscan vulnerabilities on python dependencies
-        [[ ! -f "requirements.txt" && ! -f "pyproject.toml" ]] || pyscan -d .
+    - name: Pysentry to scan for transitive vulnerabilities on required dependencies
+      shell: bash
+      run: pysentry-rs --fail-on high --exclude-extra --no-fail-on-unknown --forbid-quarantined
 
     - shell: bash
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ optional-dependencies.test = [
   "coverage",
   "flake8",
   "isort",
-  "pyscan-rs",
+  "pysentry-rs",
   "twine",
 ]
 urls.Changelog = "https://www.notavailable.com/changelog"


### PR DESCRIPTION
<!-- NOTE: Terraform-managed template -->
<!-- Describe the issue -->
#### Issue Summary
_pysentry is more user-friendly and well-maintained than pyscan-rs_

#### Why is this PR created?
This PR accomplishes the following....
- Replace Python security scan from pyscan to pysentry