### PR TITLE
build: Replace app-id with client-id

### DIFF
--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -39,7 +39,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SECRET_GITHUB_APP_ID }}
+          client-id: ${{ secrets.SECRET_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.SECRET_GITHUB_APP_PEM_FILE }}
 
       - name: Checkout source code # https://github.com/marketplace/actions/checkout


### PR DESCRIPTION
<!-- NOTE: Terraform-managed template -->
<!-- Describe the issue -->

#### Issue Summary
_`app-id` of `actions/create-github-app-token` was deprecated_

<!-- What is the goal of the Pull Request? -->

#### Why is this PR created?
_This PR accomplishes the following...._
- get client_id from GitHub app settings
- apply client_id secrets to all repos