### PR TITLE
build: fix out of sync uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,4 @@ version_files = [
 major_version_zero = false
 tag_format = "$version"
 update_changelog_on_bump = true
+pre_bump_hooks = [ "uv lock" ]


### PR DESCRIPTION
<!-- NOTE: Terraform-managed template -->
<!-- Describe the issue -->

#### Issue Summary

_Summary of the issue_
Commitizen defaults to updating pyproject.toml alone (or using standard pep621 versioning), leaving uv.lock out of sync when the version bump commit and tag are created.

<!-- What is the goal of the Pull Request? -->

#### Why is this PR created?

_This PR accomplishes the following...._
- Add pre_bump_hooks to run uv lock before cz bump